### PR TITLE
Generic auto-package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Pack Results (packages)
 *.nupkg
+.build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # CharlesChocolateyPackage
-Chocolatey Nuget Package for Charles Proxy
+A (Chocolatey Nuget)[https://chocolatey.org/] package for (Charles Proxy)[https://www.charlesproxy.com/].

--- a/Source/charles.nuspec
+++ b/Source/charles.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>Charles</id>
     <title>Charles Web Debugging Proxy Application</title>
-    <version>3.11.2.1</version>
+    <version>0.0.0.1</version>
     <authors>Charles</authors>
     <owners>kevnord</owners>
     <summary>Charles Web Debugging Proxy Application</summary>
@@ -13,6 +13,7 @@
     <tags>charles web debugging proxy admin</tags>
     <licenseUrl>https://www.charlesproxy.com/buy/eula/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>XK72 Limited</copyright>
     <iconUrl>https://pbs.twimg.com/profile_images/183591433/charles_icon_bigger.png</iconUrl>
     <releaseNotes>https://www.charlesproxy.com/documentation/version-history/</releaseNotes>
     <packageSourceUrl>https://github.com/kevnord/CharlesChocolateyPackage</packageSourceUrl>

--- a/Source/tools/chocolateyinstall.ps1
+++ b/Source/tools/chocolateyinstall.ps1
@@ -1,27 +1,22 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
-
-$packageName= 'Charles' # arbitrary name for the package, used in messages
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.charlesproxy.com/assets/release/3.11.2/charles-proxy-3.11.2-win32.msi' # download url
-$url64      = 'https://www.charlesproxy.com/assets/release/3.11.2/charles-proxy-3.11.2-win64.msi' # 64bit URL here or remove - if installer is both, use $url
 
 $packageArgs = @{
-  packageName   = $packageName
+  packageName   = 'Charles' # arbitrary name for the package, used in messages
   unzipLocation = $toolsDir
   fileType      = 'msi' #only one of these: exe, msi, msu
-  url           = $url
-  url64bit      = $url64
+  url           = '{{Url32}}'
+  url64bit      = '{{Url64}}'
 
   #MSI
-  silentArgs    = "/qn /norestart"# /l*v `"$env:TEMP\chocolatey\$($packageName)\$($packageName).MsiInstall.log`"" # ALLUSERS=1 DISABLEDESKTOPSHORTCUT=1 ADDDESKTOPICON=0 ADDSTARTMENU=0
+  silentArgs    = "/qn /norestart"
   validExitCodes= @(0, 3010, 1641)
 
   softwareName  = 'Charles*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
-  checksum      = ''
-  checksumType  = 'md5' #default is md5, can also be sha1
-  checksum64    = ''
-  checksumType64= 'md5' #default is checksumType
+  checksum      = '{{Checksum32}}'
+  checksumType  = 'sha1'
+  checksum64    = '{{Checksum64}}'
+  checksumType64= 'sha1'
 }
 
 Install-ChocolateyPackage @packageArgs
-

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,43 @@
+#Requires -Version 4
+Param(
+    [Parameter(Mandatory=$true)]$charlesVersion
+)
+
+$url32 = "https://www.charlesproxy.com/assets/release/$charlesVersion/charles-proxy-$charlesVersion-win32.msi"
+$url64 = "https://www.charlesproxy.com/assets/release/$charlesVersion/charles-proxy-$charlesVersion-win64.msi"
+
+$buildPath = "$PSScriptRoot\.build"
+$stagePath = "$buildPath\stage"
+$tempPath = "$buildPath\temp"
+$packagePath = "$buildPath\package"
+
+if (Test-Path $buildPath) {
+    Remove-Item -Recurse -Force $buildPath
+}
+
+New-Item -Type Directory $buildPath | Out-Null
+New-Item -Type Directory $stagePath | Out-Null
+New-Item -Type Directory $tempPath | Out-Null
+
+Write-Host 'Downloading x32 for hash...give it a minute...'
+(New-Object System.Net.WebClient).DownloadFile($url32, "$tempPath\charles32.msi")
+Write-Host 'Downloading x64 for hash...give it a minute...'
+(New-Object System.Net.WebClient).DownloadFile($url64, "$tempPath\charles64.msi")
+
+$checksum32 = Get-FileHash -Path "$tempPath\charles32.msi" -Algorithm sha1
+$checksum64 = Get-FileHash -Path "$tempPath\charles64.msi" -Algorithm sha1
+
+Copy-Item -Recurse -Path '.\Source\*' -Destination $stagePath
+(Get-Content "$stagePath\tools\chocolateyinstall.ps1") `
+    -Replace '{{Url32}}', $url32 `
+    -Replace '{{Url64}}', $url64 `
+    -Replace '{{Checksum32}}', $checksum32.Hash `
+    -Replace '{{Checksum64}}', $checksum64.Hash `
+    | Set-Content "$stagePath\tools\chocolateyinstall.ps1"
+
+Push-Location $stagePath
+choco pack charles.nuspec --Version=$charlesVersion
+Move-Item Charles.$charlesVersion.nupkg "$packagePath\"
+Pop-Location
+
+Write-Host "Your package is ready at $packagePath\Charles.$charlesVersion.nupkg"


### PR DESCRIPTION
This pull request updates the Charles Proxy package so that the source files are generic and tokenized. A build script was created to generate the package based off a given version. The templates were updated to include sha1 hashes per the latest Chocolatey recommendations.

It appears that old versions of Charles Proxy are unavailable for download. At the time of this comment, a package will need to be generated and published for "4.0" and "3.11.5" using `.\build.ps1 "<SpecifyVersionHere>"`.